### PR TITLE
Rename herringcove.js to hc.js and remove extra line

### DIFF
--- a/js/hc.js
+++ b/js/hc.js
@@ -5,8 +5,6 @@ $(document).ready(function() {
     $(".showcase-wrapper").fadeIn("slow");
 });
 
-});
-
 /*
 var toggle = false;
 $('.nav-toggle').on('click', function () {


### PR DESCRIPTION
Hi @arnp. I starting using herring-cove today for a Jekyll blog I'm starting, and I noticed that the footer references `hc.js` when the file's actually called `herringcove.js`. I renamed the file to `hc.js` to maintain consistency (`hc.css` is also defined).

I also removed an unnecessary line of javascript that was preventing the script from being loaded.

Loving the theme so far, thanks for making it!
