### PR TITLE
Fix demo links

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,16 +10,16 @@ layout: default
   <h1>Recent Posts</h1>
 
     <ul class="homepage-posts most-recent">
-    <li><span><h4><a href="/jekyll/testing/2013/12/08/What-is-this-anyway.html">What is this, anyway?</a>&nbsp;<span class="badge"><smaller>FRESH</smaller></span><time class="pull-right">08 Dec 2013</h4></time></span></h4></span></li>
+    <li><span><h4><a href="{{ site.baseurl }}/jekyll/testing/2013/12/08/What-is-this-anyway.html">What is this, anyway?</a>&nbsp;<span class="badge"><smaller>FRESH</smaller></span><time class="pull-right">08 Dec 2013</h4></time></span></h4></span></li>
     </ul>
 
 
     <ul class="homepage-posts">
- 	  <li><span><h4><a href="/2013/12/04/Samples.html">Samples</a><time class="pull-right">04 Dec 2013</h4></time></span></h4></span></li>
+ 	  <li><span><h4><a href="{{ site.baseurl }}/2013/12/04/Samples.html">Samples</a><time class="pull-right">04 Dec 2013</h4></time></span></h4></span></li>
     </ul>
 
     <ul class="homepage-posts">
- 	  <li><span><h4><a href="/jekyll/update/2013/11/08/welcome-to-jekyll.html">Welcome to Jekyll!</a><time class="pull-right">08 Nov 2013</h4></time></span></h4></span></li>
+ 	  <li><span><h4><a href="{{ site.baseurl }}/jekyll/update/2013/11/08/welcome-to-jekyll.html">Welcome to Jekyll!</a><time class="pull-right">08 Nov 2013</h4></time></span></h4></span></li>
     </ul>
 
     <ul>


### PR DESCRIPTION
Demo links in index.html don't take into account site.baseurl which is unfortunate because the default config is site.baseurl = /herring-cove, so these links 404 on a fresh install.
